### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,15 @@ class ItemsController < ApplicationController
     redirect_to root_path
   end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
 
-  before_action :set_item, only: [:show] # , :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update] # :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -27,14 +27,12 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
     return unless current_user.id != @item.user_id
 
     redirect_to root_path
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(item_params)
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,10 +35,12 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    if @item.update(item_params)
-      redirect_to item_path
+    # バリデーションがOKであれば詳細画面へ
+    if @item.valid?
+      redirect_to item_path(item_params)
     else
-      render :edit
+      # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
+      render 'edit'
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
 
   before_action :set_item, only: [:show] # , :edit, :update, :destroy]
 
@@ -24,6 +24,13 @@ class ItemsController < ApplicationController
   end
 
   def show
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+    return unless current_user.id != @item.user_id
+
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,12 +35,11 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    # バリデーションがOKであれば詳細画面へ
-    if @item.valid?
+    if @item.update(item_params)
       redirect_to item_path(item_params)
     else
       # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
-      render 'edit'
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -130,7 +130,7 @@ app/assets/stylesheets/items/new.css %>
 
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる' ,edit_item_path , class:"back-btn" %>
+      <%=link_to 'もどる' ,item_path , class:"back-btn" %>
     </div>
 
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
 
@@ -30,7 +30,7 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-
+    
+    <%# エラーメッセージ %>
     <%= form_with model: @item,local: true do |f| %>
     <% render 'shared/error_messages', model: f.object %>
 
@@ -92,7 +93,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -36,7 +36,7 @@ app/assets/stylesheets/items/new.css %>
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
 
@@ -47,12 +47,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
 
@@ -66,17 +66,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id,ShippingCost.all,:id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area_id,ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -130,7 +130,7 @@ app/assets/stylesheets/items/new.css %>
 
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる' ,root_path , class:"back-btn" %>
+      <%=link_to 'もどる' ,edit_item_path , class:"back-btn" %>
     </div>
 
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
     
     <%# エラーメッセージ %>
     <%= form_with model: @item,local: true do |f| %>
-    <% render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -130,7 +130,7 @@ app/assets/stylesheets/items/new.css %>
 
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる' ,root_path , class:"back-btn" %>
     </div>
 
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,7 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     
-    <%= form_with model: @item, local: true do |f| %>
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -6,7 +6,7 @@
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     
-    <%= form_with model: @item, url: item_path, local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,8 +30,7 @@
     <%# 出品者かつ未購入品であれば、編集・削除を表示 %>
     <% if current_user.id == @item.user_id #&& @item.order.nil? %> 
 
-    <%= link_to '商品の編集',"#", method: :get, class: "item-red-btn" %>
-    <%#= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to '削除',"#", method: :delete, class:'item-destroy' %>
     <%#= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>


### PR DESCRIPTION
WHAT:商品情報編集機能実装
WHY:フリマアプリ商品情報編集機能のため


＜ログイン状態の出品者は、商品情報編集ページに遷移できる動画＞
https://gyazo.com/883909fd8e09e59cd4571047102f349e

 ＜必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画＞
https://gyazo.com/e59153a65c6d8867f00d5f3acc614dcd

＜入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画＞
https://gyazo.com/e286403cfbf004d78a2ea794d981c1a4

＜何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画＞
https://gyazo.com/29e7c358acd526c0161d5bfaf63da0c5

＜商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）＞
https://gyazo.com/7cab1544e8c296a9e0d0cd974bc4fce4

その他購入機能終えてからの添付